### PR TITLE
sets visibility to public for the ImageStack.StackBitmap nested class

### DIFF
--- a/GVLXamarinAndroid/GVLXamarinAndroid/Transforms/Metadata.xml
+++ b/GVLXamarinAndroid/GVLXamarinAndroid/Transforms/Metadata.xml
@@ -19,4 +19,6 @@
     
     <attr path="/api/package[@name='net.gini.android.vision.review']/interface[@name='ReviewFragmentListener']/method[@name='onProceedToAnalysisScreen' and count(parameter)=2]/parameter[@name='p0']"
         name="name">p00</attr>
+    
+    <attr path="/api/package[@name='net.gini.android.vision.camera']/class[@name='ImageStack.StackBitmap']" name="visibility">public</attr>
 </metadata>


### PR DESCRIPTION
For some reason the nested class was not visible anymore. Changing the visibility to public in `Metadata.xml` fixed the build errors.